### PR TITLE
refactor: AI경험카드 조회페이지 디자인 리팩토링

### DIFF
--- a/src/main/frontend/src/app/card/Card.tsx
+++ b/src/main/frontend/src/app/card/Card.tsx
@@ -110,7 +110,7 @@ export default function Card({
   }
 
   return (
-    <div className={`${style ? style : ''} w-[400px] h-[75dvh] max-h-[600px] relative mb-4`}>
+    <div className={`${style ? style : ''} w-[390px] h-[80dvh] max-h-[770px] relative mb-4`}>
       <motion.div
         className='w-full h-full relative'
         initial={false}
@@ -127,18 +127,26 @@ export default function Card({
             backfaceVisibility: 'hidden'
           }}
         >
-          <div className='w-full h-1/3 mb-2'>
+          <div className='w-full h-2/3 px-6 py-6'>
             {card.imageUrl && (
-              <img className='w-full h-full object-cover rounded-t-xl' src={card.imageUrl} alt='' />
+              <img className='w-full h-full object-cover rounded-xl' src={card.imageUrl} alt='' />
             )}
           </div>
           <div className='w-full h-2/3 flex flex-col justify-around'>
-            <div className='flex flex-col justify-between items-start px-4'>
+            <div className='flex flex-col justify-between items-start px-5'>
               {(card.fromDate || card.toDate) && (
-                <div className='font-normal text-gray-cc'>{card.fromDate} ~ {card.toDate}</div>
+                <div className='font-normal text-black text-sm'>{card.fromDate} ~ {card.toDate}</div>
               )}
               {card.title && (
-                <div className='font-semibold text-2xl mb-3'>{card.title}</div>
+                <div className='font-semibold text-3xl mb-3'>{card.title}</div>
+              )}
+              {card.reflection && (
+                  <>
+                    <div className='line-clamp-4 text-sm mb-2'>
+                      {card.reflection}
+                    </div>
+                    <div className='mb-4 w-full border-t border-gray-d9'/>
+                  </>
               )}
               <div className='w-full flex justify-between items-center'>
                 <div className='flex items-center'>
@@ -183,12 +191,8 @@ export default function Card({
                 )}
               </div>
             </div>
-            <div className='h-1/3 flex flex-col justify-between px-4 pb-2'>
+            <div className='flex flex-col justify-between px-4 pb-2'>
               {card.reflection && (
-                <>
-                  <div className='line-clamp-4 text-sm mt-2 font-semibold'>
-                    {card.reflection}
-                  </div>
                   <div className='flex justify-end items-end'>
                     <button
                       onClick={handleFlip}
@@ -197,12 +201,13 @@ export default function Card({
                       {'자세히 보기 ->'}
                     </button>
                   </div>
-                </>
               )}
             </div>
           </div>
 
         </motion.div>
+
+        {/*카드뒷면*/}
         <motion.div
           className={`absolute overflow-y-auto scrollbar w-full h-full flex flex-col justify-between items-start bg-white rounded-xl shadow-[4px_4px_8px_rgba(0,0,0,0.3)] ${!isFlipped ? 'rotate-y-180' : ''}`}
           style={{

--- a/src/main/frontend/src/app/card/CardRetrieve.tsx
+++ b/src/main/frontend/src/app/card/CardRetrieve.tsx
@@ -82,7 +82,7 @@ export default function CardRetrieve({
           </div>
         ))}
         <div 
-          className='w-[400px] h-[75dvh] max-h-[600px] cursor-pointer flex justify-center items-center mb-4 border-2 border-dashed border-gray-d9'
+          className='w-[400px] h-[75dvh] max-h-[780px] cursor-pointer flex justify-center items-center mb-4 border-2 border-dashed border-gray-d9'
           onClick={()=>onChangePage({})}
           >
           <div className='text-3xl font-bold text-gray-d9'>+</div>

--- a/src/main/frontend/src/app/category/TimeLineRoadMap.tsx
+++ b/src/main/frontend/src/app/category/TimeLineRoadMap.tsx
@@ -18,17 +18,20 @@ function TimelineRoadmap({ skills }: { skills: RoadmapSkill[] }) {
             <div className="font-bold">Timeline Roadmap</div>
             <div className="font-semibold text-category-front">Web_FrontEnd</div>
             <div className="w-full flex flex-wrap gap-4 justify-center mt-4">
-                {sortedSkills.map((skill) => (
-                    <div key={skill.id} className="p-2">
+
+                <svg width="100%" height="40%">
+                    {sortedSkills.map((skill) => (
                         <SkillNode
+                            key={skill.id}
                             skill={skill}
-                            scale={1}
+                            scale={20}
                             isSelected={false}
                             onSelect={undefined}
                             onDrag={undefined}
                         />
-                    </div>
-                ))}
+
+                    ))}
+                </svg>
             </div>
         </div>
     );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/696c5fae-2fe8-413f-9f17-a135f3a2a99a)
경험카드 기본적인 디자인 변경 완료
- 프로젝트 기간 : 글자색, 굵기, 크기 변경 완료(회색 -> 검정색)
- 이미지 크기의 경우, 경험카드에 들어간 태그 값의 개수가 많으면 자동으로 줄어들게 설정
- width를 줄이고 height를 늘림
- 중간에 구분선 추가
- 모서리 둥글게 깎기