### PR TITLE
Refactor: navbar

### DIFF
--- a/src/main/frontend/src/app/card/CardRetrieve.tsx
+++ b/src/main/frontend/src/app/card/CardRetrieve.tsx
@@ -73,9 +73,9 @@ export default function CardRetrieve({
   onChangePage
 }: CardRetrieveProps) {
   return (
-    <div className='w-full h-full flex flex-col items-center justify-center'>
-      <div className='w-full text-2xl font-gmarketsansMedium mb-4 ml-8'>AI경험카드 관리</div>
-      <div className='w-full h-full grid grid-cols-3 gap-4 ml-8'>
+    <div className='w-full h-full flex flex-col items-center justify-center px-24'>
+      <div className='w-full text-2xl font-gmarketsansMedium mb-4'>AI경험카드 관리</div>
+      <div className='w-full h-full grid grid-cols-3 gap-4'>
         {cardInfos.map((card, index) => (
           <div className='cursor-pointer' key={index} onClick={()=>onChangePage(card)}>
             <Card card={card} />

--- a/src/main/frontend/src/app/card/pageComponents.tsx
+++ b/src/main/frontend/src/app/card/pageComponents.tsx
@@ -16,7 +16,7 @@ export default function CardPage() {
   }
 
   return (
-    <div className='w-full h-full flex flex-col items-center'>
+    <div className='w-full h-full flex flex-col items-center mt-5'>
       <div className='w-[1400px] h-full'>
         {isCreatePage ? (
           <CardEditor selectedCard={selectedCard} onChangePage={onSaveCard}/> 

--- a/src/main/frontend/src/app/mypage/pageComponents.tsx
+++ b/src/main/frontend/src/app/mypage/pageComponents.tsx
@@ -162,7 +162,7 @@ export default function MypagePage() {
   } 
 
   return (
-    <div className="w-full h-full flex flex-col items-center">
+    <div className="w-full h-full flex flex-col items-center mt-5">
       <div className='w-[1400px] h-full'>
         <div className='w-full flex flex-col px-24 pb-10 border-b border-gray-cc'>
           <div className='font-bold text-2xl mb-5'>마이페이지</div>

--- a/src/main/frontend/src/components/Navbar.tsx
+++ b/src/main/frontend/src/components/Navbar.tsx
@@ -1,15 +1,20 @@
 import Link from 'next/link';
 const NavigationBar = () =>{
     return(
-        <nav className={"p-4 justify-center"}>
-            <ul className={"sticky top-0 left-0 right-0 bottom-0 justify-center items-center flex space-x-10"}>
-                <li><Link href="/main"><img src="/asset/png/servicelogo.png" alt="logoimg" className={"w-20 pb-3"}></img></Link></li>
-                <li><Link href="/category" className={"hover:underline text-sm font-gmarketsansMedium"}>직무별로드맵</Link></li>
-                <li><Link href="/company" className={"hover:underline text-sm font-gmarketsansMedium"}>기업별로드맵</Link></li>
-                <li><Link href="/card" className={"hover:underline text-sm font-gmarketsansMedium"}>AI경험카드</Link></li>
-                <li><Link href="/aiChatbot" className={"hover:underline text-sm font-gmarketsansMedium"}>AI경험Chat</Link></li>
-                <li><Link href="/mypage" className={"hover:underline text-sm font-gmarketsansMedium"}>마이페이지</Link></li>
-            </ul>
+        <nav className={"flex justify-center items-center py-5 border-b border-gray-d9"}>
+            <div className={'w-[1400px] flex justify-between items-center px-24'}>
+                <ul className={"sticky top-0 left-0 right-0 bottom-0 justify-center items-center flex space-x-20"}>
+                    <li><Link href="/main"><img src="/asset/png/service_full_logo.png" alt="logoimg" className={"w-40"}></img></Link></li>
+                    <li><Link href="/category" className={"hover:underline text-sm font-gmarketsansMedium"}>직무별로드맵</Link></li>
+                    <li><Link href="/company" className={"hover:underline text-sm font-gmarketsansMedium"}>기업별로드맵</Link></li>
+                    <li><Link href="/card" className={"hover:underline text-sm font-gmarketsansMedium"}>AI경험카드</Link></li>
+                    <li><Link href="/aiChatbot" className={"hover:underline text-sm font-gmarketsansMedium"}>AI경험Chat</Link></li>
+                    <li><Link href="/mypage" className={"hover:underline text-sm font-gmarketsansMedium"}>마이페이지</Link></li>
+                </ul>
+                <div className='flex items-center border-2 border-primary text-sm font-gmarketsansMedium px-3 pb-1 pt-2 rounded-xl cursor-pointer hover:bg-gray-ec'>
+                    <Link href="/signin">회원가입/로그인</Link>
+                </div>
+            </div>
         </nav>
     );
 };


### PR DESCRIPTION
### Description
상단 navbar 디자인 수정 및 로그인 버튼 추가하였습니다.
사진 첨부는 중간발표때 보일 페이지들입니다. 각 페이지의 양 옆 공백 크기를 통일하고, navbar도 동일하게 맞췄습니다.
`회원가입/로그인` 버튼을 누르면 `/signin`페이지로 넘어갑니다.
또한 로그인 기능이 완료되어 세션에 로그인 정보를 담을 수 있게 된다면, `AI경험카드`, `AI경험Chat`, `마이페이지`은 로그인 정보가 잇어야하기 때문에 로그인 페이지로 리다이렉트할 예정입니다.

### Changes
- Navbar.tsx 수정

### Result
![image](https://github.com/user-attachments/assets/b5bfa0f1-b70d-4b5c-8696-9671dbdb93b7)
![image](https://github.com/user-attachments/assets/33dd6cb9-b2ec-47c4-8284-a8bafad7f0ae)
![image](https://github.com/user-attachments/assets/d7d0819b-c2a9-4222-9bd6-7f6931b66930)
![image](https://github.com/user-attachments/assets/c1236400-4ac5-413d-8f28-fce8f3189f98)

