### PR TITLE
refactor: ai-card-page-mobile-ui

### DIFF
--- a/src/main/frontend/src/app/card/Card.tsx
+++ b/src/main/frontend/src/app/card/Card.tsx
@@ -112,7 +112,7 @@ export default function Card({
   // }
 
   return (
-    <div className={`${style ? style : ''} w-full h-[65dvh] xs:w-[400px] xs:h-[75dvh] max-h-[600px] relative mb-4`}>
+    <div className={`${style ? style : ''} w-full h-[75dvh] max-h-[600px] relative mb-4`}>
       <motion.div
         className='w-full h-full relative'
         initial={false}
@@ -129,7 +129,7 @@ export default function Card({
             backfaceVisibility: 'hidden'
           }}
         >
-          <div className='w-full h-2/3 px-5 pt-5 pb-2'>
+          <div className='w-full h-1/2 px-5 pt-5 pb-2'>
             {card?.imageUrl && (
               <img className='w-full h-full object-cover rounded-t-xl' src={card?.imageUrl} alt='' />
             )}
@@ -140,7 +140,7 @@ export default function Card({
                 <div className='font-normal text-gray-cc'>{card?.fromDate} ~ {card?.toDate}</div>
               )}
               {card?.title && (
-                <div className='font-semibold text-3xl mb-2'>{card?.title}</div>
+                <div className='font-semibold text-2xl mb-2'>{card?.title}</div>
               )}
               <div className='w-full flex justify-between items-center'>
                 <div className='flex items-center'>

--- a/src/main/frontend/src/app/card/CardEditor.tsx
+++ b/src/main/frontend/src/app/card/CardEditor.tsx
@@ -294,6 +294,15 @@ export default function CardEditor({
   const [buttonStyles, setButtonStyles] = useState(Array(categories.length).fill('border-primary'));
   const [selectedSkills, setSelectedSkills] = useState<Skill[]>([]);
   const [isLoading, setIsLoading] = useState(false); // 로딩
+  const [isSidePanelOpen, setSidePanelOpen] = useState(false);
+
+  const toggleSidePanel = () => {
+    setSidePanelOpen(!isSidePanelOpen);
+  };
+
+  const closeSidePanel = () => {
+    setSidePanelOpen(false);
+  };
 
   // 1. 제목과 기간
   const handlerTitleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -390,18 +399,6 @@ export default function CardEditor({
     }))
   }
 
-  // 6. 경험 이미지 업로드
-  // const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-  //   const file = event.target.files?.[0];
-  //   if (file) {
-  //     setCard(prevCard => ({
-  //       ...prevCard,
-  //       imageFile : file,
-  //       imageUrl: `/asset/png/profile/${file.name}`
-  //     }))
-  //   }
-  // };
-
   // 6. pdf 참고자료
   const handlePdfUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -477,15 +474,15 @@ export default function CardEditor({
   }, [card]);
   
   return (
-    <div className='w-full h-full flex flex-row justify-between px-24'>
-      <div className='w-[65%] h-full flex flex-col items-end'>
+    <div className='w-full h-full flex flex-row justify-between'>
+      <div className='w-full lg:w-[65%] h-full flex flex-col items-end'>
         <CardEditorFormSection title="경험의 제목과 기간을 입력해주세요">
           <div className='flex flex-row w-full justify-around mb-2'>
-            <div className='w-1/6 mr-2 text-sm rounded-xl border-gray-d9 bg-primary font-semibold text-white flex justify-center items-center'>경험 제목</div>
-            <div className='w-5/6'>
+            <div className='w-1/5 md:w-1/6 mr-2 text-xs xs:text-sm rounded-xl border-gray-d9 bg-primary font-semibold text-white flex justify-center items-center'>경험제목</div>
+            <div className='w-4/5 md:w-5/6'>
               <Input 
                 type='text'
-                className='w-full rounded-xl border-gray-d9 text-sm focus:outline-0'
+                className='w-full rounded-xl border-gray-d9 text-xs xs:text-sm focus:outline-0'
                 placeholder='제목을 입력해주세요'
                 value={card?.title}
                 onChange={handlerTitleInput}
@@ -493,22 +490,22 @@ export default function CardEditor({
             </div>
           </div>
           <div className='flex flex-row w-full justify-around'>
-            <div className='w-1/6 mr-2 text-sm rounded-xl border-gray-d9 bg-primary font-semibold text-white flex justify-center items-center'>기간</div>
-            <div className='w-5/6 flex flex-row'>
-              <div className='flex flex-row w-1/6'>
+            <div className='w-1/5 md:w-1/6 mr-2 text-xs xs:text-sm rounded-xl border-gray-d9 bg-primary font-semibold text-white flex justify-center items-center'>기간</div>
+            <div className='w-4/5 md:w-5/6 flex flex-row'>
+              <div className='flex flex-row w-2/5 md:w-1/6'>
                 <Input 
                   type='text'
-                  className='w-full rounded-xl border-gray-d9 text-sm focus:outline-0'
+                  className='w-full rounded-xl border-gray-d9 text-xs xs:text-sm focus:outline-0'
                   placeholder='YYYY-MM-DD'
                   value={card?.fromDate}
                   onChange={handlerFromDateInput}
                 />
               </div>
               <div className='flex text-2xl text-gray-d9 justify-center items-center mx-2'>&#126;</div>
-              <div className='flex flex-row w-1/6'>
+              <div className='flex flex-row w-2/5 md:w-1/6'>
                 <Input 
                   type='text'
-                  className='w-full rounded-xl border-gray-d9 text-sm focus:outline-0'
+                  className='w-full rounded-xl border-gray-d9 text-xs xs:text-sm focus:outline-0'
                   placeholder='YYYY-MM-DD'
                   value={card?.toDate}
                   onChange={handlerToDateInput}
@@ -519,7 +516,7 @@ export default function CardEditor({
         </CardEditorFormSection>
         { card?.title && card?.fromDate && card?.toDate && card?.title.length > 0 && (
           <CardEditorFormSection title="내가 맡았던 역할은 무엇인가요?">
-            <div className='flex flex-row w-full justify-between'>
+            <div className='w-full grid grid-cols-2 sm:grid-cols-3 gap-2'>
               {categories.map((c, index) => (
                 <ButtonLabel 
                   key={c}
@@ -578,31 +575,6 @@ export default function CardEditor({
             />
           </CardEditorFormSection>
         )}
-        {/* { card?.reflection && card?.reflection.length > 0 && (
-          <CardEditorFormSection title="사진으로 경험을 보여주세요">
-            <div className='w-full flex'>
-              <label className='cursor-pointer inline-flex items-center mr-4 py-2 px-4 rounded-lg border-0 text-sm font-semibold bg-primary text-white'>
-                <Input 
-                  type='file'
-                  accept='image/*'
-                  className='hidden'
-                  onChange={handleImageUpload}
-                />
-                파일 선택
-              </label>
-              {card?.imageUrl && (
-                <div className="mt-2 font-semibold">{card?.imageUrl}</div> 
-              )}
-            </div>
-            {card?.imageUrl && (
-              <img
-                src={card?.imageUrl}
-                alt="Preview"
-                className="mt-4 w-1/2 h-1/2 object-cover border border-gray-d9 rounded-xl"
-              />
-            )}
-          </CardEditorFormSection>
-        )} */}
         { card?.reflection && card?.reflection.length > 0 && (
           <CardEditorFormSection title="경험을 가장 잘 보여주는 자료(.pdf)">
             <div className='w-full flex'>
@@ -622,7 +594,7 @@ export default function CardEditor({
           </CardEditorFormSection>
         )}
         { card?.pdfName && card?.pdfName.length > 0 && (
-          <CardEditorFormSection title="경험을 보여주는 소스 URL을 입력해주세요">
+          <CardEditorFormSection title="경험이 담긴 소스 URL을 입력해주세요">
             {[0, 1].map(index => (
               <Input 
                 key={index}
@@ -635,9 +607,27 @@ export default function CardEditor({
             ))}
           </CardEditorFormSection>
         )}
+        <div className='w-full lg:hidden'>
+          {card?.sourceUrl && card?.sourceUrl.length > 0 ? (
+            <div
+              className='cursor-pointer w-full flex justify-center font-semibold bg-primary text-white border-2 border-primary hover:text-primary hover:bg-white px-4 py-2 mt-2 rounded-xl'
+              onClick={handleSaveClick}
+            >
+              {isNewCard ? 'AI경험카드 생성하기' : 'AI경험카드 수정하기'}
+            </div>
+          ) :
+          (
+            <div
+              className='cursor-pointer w-full flex justify-center font-semibold bg-primary text-white border-2 border-primary hover:text-primary hover:bg-white px-4 py-2 mt-2 rounded-xl'
+              onClick={handleCancelClick}
+            >
+              {'AI경험카드 관리 돌아가기'}
+            </div>
+          )}
+        </div>
       </div>
-      <div className='w-1/3 flex flex-col items-center'>
-        <div className='fixed'>
+      <div className='hidden lg:w-1/3 lg:flex flex-col items-center'>
+        <div className='w-1/4 fixed'>
           <Card card={card}/>
           {card?.sourceUrl && card?.sourceUrl.length > 0 ? (
             <div
@@ -657,6 +647,37 @@ export default function CardEditor({
           )}
         </div>
       </div>
+
+      <div className="lg:hidden fixed top-16 right-0 z-40">
+        <button
+          className="w-28 p-3 text-xs rounded-l-lg bg-primary text-white shadow-lg"
+          onClick={toggleSidePanel}
+        >
+          {isSidePanelOpen ? '닫기' : '카드 미리보기'}
+        </button>
+      </div>
+
+      {isSidePanelOpen && (
+        <>
+          <div
+            className="fixed inset-0 bg-gray-45 bg-opacity-50 z-50"
+            onClick={closeSidePanel}
+          ></div>
+
+          <div className="fixed top-0 right-0 w-4/5 h-full bg-white shadow-lg z-50 p-8">
+            <div className='font-bold text-medium sm:text-lg mb-3 sm:mb-6'>현재 AI경험카드</div>
+            <Card card={card} />
+            <div className='w-full flex justify-end mt-4 '>
+              <button
+                className="w-28 p-3 text-xs rounded-lg bg-primary text-white shadow-lg"
+                onClick={closeSidePanel}
+              >
+                {isSidePanelOpen ? '닫기' : '카드 보기'}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/main/frontend/src/app/card/CardEditorFormSection.tsx
+++ b/src/main/frontend/src/app/card/CardEditorFormSection.tsx
@@ -5,7 +5,7 @@ type CardEditorFormSectionProps = {
   
   const CardEditorFormSection = ({ title, children }: CardEditorFormSectionProps) => (
     <div className="w-full flex flex-col items-center justify-around border border-gray-d9 rounded-xl p-4 mb-6">
-      <div className="font-bold text-lg mb-6">{title}</div>
+      <div className="font-bold text-medium sm:text-lg mb-3 sm:mb-6">{title}</div>
       {children}
     </div>
   );

--- a/src/main/frontend/src/app/card/CardRetrieve.tsx
+++ b/src/main/frontend/src/app/card/CardRetrieve.tsx
@@ -2,6 +2,7 @@
 
 import React, {useEffect, useState} from 'react';
 import Card from './Card';
+import Slider from 'react-slick';
 import {AiCard, AiCardWithNew} from "@/models/card";
 
 type CardRetrieveProps = {
@@ -11,6 +12,15 @@ type CardRetrieveProps = {
 // 카드를 관리하는 컴포넌트
 export default function CardRetrieve({ onChangePage }: CardRetrieveProps) {
   const [cardInfos, setCardInfos] = useState<AiCard[]>([]);
+
+  const cardSlideSettings = {
+    dots: true, // 슬라이더 하단에 점 표시
+    infinite: false, // 무한 반복
+    speed: 500, // 슬라이딩 속도
+    slidesToShow: 1, // 한 번에 보여줄 슬라이드 개수
+    slidesToScroll: 1, // 스크롤할 슬라이드 개수
+    arrows: true, // 좌우 화살표 표시
+  };
 
   useEffect(() => {
     // 백엔드에서 데이터 가져오기
@@ -40,20 +50,43 @@ export default function CardRetrieve({ onChangePage }: CardRetrieveProps) {
   };
 
   return (
-      <div className='w-full h-full flex flex-col items-center justify-center px-24'>
-        <div className='w-full text-2xl font-gmarketsansMedium mb-4'>AI경험카드 관리</div>
-        <div className='w-full h-full grid grid-cols-3 gap-4'>
+    <div className='w-full h-full flex flex-col items-center justify-center'>
+      <div className='w-full text-2xl font-gmarketsansMedium mb-4 ml-14 xs:ml-20 sm:ml-0'>AI경험카드 관리</div>
+      <div className="hidden sm:grid w-full h-full justify-center items-center grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {cardInfos.map((card, index) => (
+          <div
+            className="flex justify-center cursor-pointer"
+            key={index}
+            onClick={() => handleCardClick(card)}
+          >
+            <Card card={card} />
+          </div>
+        ))}
+        <div
+          className="w-full h-[75dvh] max-h-[600px] cursor-pointer flex justify-center items-center mb-4 rounded-xl border-2 border-dashed border-gray-d9"
+          onClick={() => handleCardClick(null)}
+        >
+          <div className="text-3xl font-bold text-gray-d9">+</div>
+        </div>
+      </div>
+      <div className="sm:hidden w-full h-full flex items-center justify-center">
+        <Slider {...cardSlideSettings} className="w-11/12 mx-2">
           {cardInfos.map((card, index) => (
-              <div className='cursor-pointer' key={index} onClick={() => handleCardClick(card)}>
-                <Card card={card} />
-              </div>
+            <div
+              key={index}
+              className="w-full h-full flex justify-center items-center px-4"
+              onClick={() => handleCardClick(card)}
+            >
+              <Card card={card} />
+            </div>
           ))}
           <div
-              className='w-[400px] h-[580px] cursor-pointer flex justify-center items-center mb-4 rounded-xl border-2 border-dashed border-gray-d9'
-              onClick={() => handleCardClick(null)}
+            className="w-full h-[75dvh] max-h-[600px] cursor-pointer flex justify-center items-center mb-4 px-4"
+            onClick={() => handleCardClick(null)}
           >
-            <div className='text-3xl font-bold text-gray-d9'>+</div>
+            <div className="w-full h-full flex justify-center items-center rounded-xl border-2 border-dashed border-gray-d9 text-3xl font-bold text-gray-d9">+</div>
           </div>
+        </Slider>
       </div>
     </div>
   );

--- a/src/main/frontend/src/app/card/pageComponents.tsx
+++ b/src/main/frontend/src/app/card/pageComponents.tsx
@@ -84,7 +84,7 @@ export default function CardPage() {
 
   return (
     <div className='w-full h-full flex flex-col items-center mt-5'>
-      <div className='w-[1400px] h-full'>
+      <div className='max-w-[1400px] w-full h-full px-4 2xl:w-[1400px] xl:px-20 lg:px-10'>
         {isCreatePage ? (
           <CardEditor selectedCard={selectedCard} onCancel={onCancel} onCreate={onCreate} onModify={onModify}/> 
         ) : (

--- a/src/main/frontend/src/app/mypage/pageComponents.tsx
+++ b/src/main/frontend/src/app/mypage/pageComponents.tsx
@@ -174,7 +174,7 @@ export default function MypagePage({
 
   return (
     <div className="w-full h-full flex flex-col items-center mt-5">
-      <div className='max-w-[1400px] h-full px-4 2xl:w-[1400px] xl:px-20 lg:px-10'>
+      <div className='max-w-[1400px] w-full h-full px-4 2xl:w-[1400px] xl:px-20 lg:px-10'>
         <div className='w-full flex flex-col pb-5'>
           <UserProfile userInfo={userInfo} badgeInfo={badgeInfo} onSave={onSaveProfile}/>
         </div>
@@ -198,15 +198,15 @@ export default function MypagePage({
               </div>
             )}
           </div>
-          <div className='w-full lg:w-2/5 flex flex-col'>
+          <div className='w-full lg:w-[36%] flex flex-col'>
             <div className='flex flex-col'>
               <div className='flex items-center text-center text-lg md:text-2xl font-gmarketsansMedium'><img className='w-4 h-4 md:w-6 md:h-6 mb-1 mr-1' src='asset/png/icon_filter_card.png' alt='AI경험카드' />AI경험카드</div>
               <div className='text-xl font-gmarketsansMedium'>{cardInfos[currentCard]?.title || '-'}</div>
             </div>
             {cardInfos.length > 0 ? (
-              <Slider {...cardSlideSettings} className="w-full mx-auto">
+              <Slider {...cardSlideSettings} className="w-11/12 xs:w-4/5 sm:w-3/5 lg:w-5/6 mx-auto">
                 {cardInfos.map((card, index) => (
-                  <div key={index} className="w-full h-full flex justify-center items-center p-5"> 
+                  <div key={index} className="w-full  h-full flex justify-center items-center p-5"> 
                     <Card card={card} />
                   </div>
                 ))}

--- a/src/main/frontend/src/components/ButtonLabel.tsx
+++ b/src/main/frontend/src/components/ButtonLabel.tsx
@@ -26,7 +26,7 @@ export default function ButtonLabel({
   const labelName = type === 'category' ? categoryLabels[label] || label : label;
   return (
     <div
-      className={`${style ? style : "bg-primary text-white border-white"} text-sm font-semibold flex border rounded-xl px-4 py-1 mr-2 mb-2`}
+      className={`${style ? style : "bg-primary text-white border-white"} text-xs sm:text-sm font-semibold flex justify-center border rounded-xl px-1 xs:px-2 sm:px-4 py-1 mr-2 mb-2`}
       onClick={onClick ? onClick : undefined}
     >
       <img className='w-[20px] h-[20px] object-contain mr-2' src={imageSrc} alt={label}/>


### PR DESCRIPTION
### Description
- AI경험카드 관련 모바일 반응형 UI 작업입니다.
- 마이페이지에 나오는 AI경험카드
- AI경험카드 조회페이지
- AI경험카드 편집페이지

### Changes
1. 마이페이지
  - 스타일 조정
2. 경험카드 조회페이지
  - 기타 스타일 조정
  - 1024px을 기준으로 3개 열의 리스트에서 2개짜리 열 리스트로
  - 640px을 기준으로 경험카드 하나씩 나오는 캐러셀로 교체
3. 경험카드 편집페이지 
  - 기타 스타일 조정
  - 1024px을 기준으로 오른쪽 섹션 경험카드를 숨기고, 작은 버튼생성
  - 버튼을 누르면 사이드창에서 확인 가능하도록 수정

### Results
**1)** 
![image](https://github.com/user-attachments/assets/d3d99946-4bd4-4647-8172-6c2033374ec6)

**2)**
![image](https://github.com/user-attachments/assets/61c2cbd5-4b6b-4a19-896f-a91be3359da6)

**3)**
![image](https://github.com/user-attachments/assets/c7bab996-39e4-4edc-aa59-44d213e52e4b)

**4)** 
![image](https://github.com/user-attachments/assets/1b36c5fc-91bf-4cb9-a77c-0b1553cdc903)

**5)** 
![image](https://github.com/user-attachments/assets/c5c70bae-056f-4e30-99d2-f025d3d45460)
