### PR TITLE
refactor: category-roamap-page-mobile-ui

### DIFF
--- a/src/main/frontend/src/app/category/CategoryButton.tsx
+++ b/src/main/frontend/src/app/category/CategoryButton.tsx
@@ -21,12 +21,12 @@ export default function CategoryButton({
   const imageSrc = `/asset/png/category/${category}_img.png`;
   return (
     <div 
-      className='p-6 flex flex-col items-center justify-between text-sm font-semibold hover:bg-gray-dc hover:rounded-xl'
+      className='p-1 sm:p-3 md:p-4 lg:p-6 flex flex-col items-center justify-between text-sm font-semibold hover:bg-gray-dc hover:rounded-xl'
     >
-      <div className='w-fit h-fit flex items-center justify-center bg-primary rounded-xl p-4 mb-1'>
-        <img className='w-12 h-12 object-contain' src={imageSrc} alt={categoryName}/>
+      <div className='w-fit h-fit flex items-center justify-center bg-primary rounded-xl p-2 sm:p-4 mb-1'>
+        <img className='w-[25px] h-[25px] sm:w-[30px] sm:h-[30px] md:w-[40px] md:h-[40px] object-contain' src={imageSrc} alt={categoryName}/>
       </div>
-      <div>
+      <div className='text-xs md:text-sm'>
         {categoryName}
       </div>
     </div>

--- a/src/main/frontend/src/app/category/TimeLineRoadMap.tsx
+++ b/src/main/frontend/src/app/category/TimeLineRoadMap.tsx
@@ -2,6 +2,7 @@
 import React, {useMemo} from 'react';
 import SkillNode from './SkillNode';
 import {RoadmapSkill} from '@/models/skill';
+import Slider from 'react-slick';
 
 function TimelineRoadmap({ skills, category }: { skills: RoadmapSkill[], category: string }) {
   const filteredSkills = useMemo(() => {
@@ -64,67 +65,138 @@ function TimelineRoadmap({ skills, category }: { skills: RoadmapSkill[], categor
     }
   };
 
+  const settings = {
+    dots: true, 
+    infinite: false, 
+    speed: 500,
+    slidesToShow: 1, 
+    slidesToScroll: 1,
+    adaptiveHeight: true, 
+  };
+
   return (
-    <div className={`box-border justify-between my-10 flex ${bg_color} rounded-lg`}>
-      <div className="w-1/4 bg-dark-light rounded-s-lg flex justify-center p-10">
+    <div className={`box-border justify-between my-4 lg:my-10 flex ${bg_color} rounded-lg`}>
+      <div className="w-1/4 bg-dark-light rounded-s-lg flex justify-center items-center p-2 sm:p-4 md:p-8 lg:p-10">
         <img className="w-44 h-40 object-contain" src={`/asset/png/category/${category}_img.png`} alt ={category}></img>
       </div>
-      <div className={`flex flex-col items-start w-full p-4 text-${categoryInfo[category].color}`}>
-        <div className="font-bold">{categoryInfo[category].title}</div>
-        <div className="font-light">{categoryInfo[category].description}</div>
-        <svg
-          width="100%"
-          height="80%"
-          viewBox="-50 -100 2000 300" // xmin, ymin, width, height
-          className="flex items-center"
-        >
-          <line
-            x1={-50} // 바의 시작 X 좌표
-            y1={50}
-            x2={2000} // 바의 끝 X 좌표
-            y2={50} // Y 좌표는 0으로 고정
-            stroke="#ffffff"
-            strokeWidth="5"
-          />
+      <div className={`w-3/4 flex flex-col justify-center items-start p-4 text-${categoryInfo[category].color}`}>
+        <div className="font-bold text-sm sm:text-base">{categoryInfo[category].title}</div>
+        <div className="font-light text-sm sm:text-base">{categoryInfo[category].description}</div>
+        <div className='hidden lg:flex w-full h-full overflow-x-auto'>
+          <div className='h-[200px] flex items-center'>
+            <svg
+              width="100%"
+              height="80%"
+              viewBox="-50 -100 2000 300" // xmin, ymin, width, height
+              className="flex items-center"
+            >
+              <line
+                x1={-50} // 바의 시작 X 좌표
+                y1={50}
+                x2={2000} // 바의 끝 X 좌표
+                y2={50} // Y 좌표는 0으로 고정
+                stroke="#ffffff"
+                strokeWidth="5"
+              />
+              {Object.keys(groupedSkills).map((tag, groupIndex) => {
+                const skills = groupedSkills[tag];
+                const xOffset = currentXOffset;
+                const yOffset = groupIndex % 2 === 0 ? 160 : -60; // 그룹 인덱스에 따라 Y축 오프셋 조정
+
+                // 다음 그룹의 시작 위치를 계산
+                currentXOffset += skills.length * itemSpacing + groupSpacing;
+
+                const centerX = (skills.length * itemSpacing) / 2 - 50;
+
+                return (
+                  <g key={tag} transform={`translate(${xOffset},${yOffset})`}>
+                    {/* 각 스킬을 가로로 일렬로 배치 (itemIndex * itemSpacing 만큼 오른쪽으로 이동) */}
+                    {skills.map((skill, itemIndex) => (
+                      <g key={skill.id} transform={`translate(${itemIndex * itemSpacing}, 0)`}>
+                        <SkillNode
+                          skill={skill}
+                          scale={0.5}
+                          isSelected={false}
+                          onSelect={undefined}
+                          onDrag={undefined}
+                        />
+                      </g>
+                    ))}
+                    <text 
+                      x={centerX} 
+                      y={groupIndex % 2 === 0 ? -70 : 90} 
+                      textAnchor="middle" 
+                      fontSize="25" 
+                      fontWeight="bold" 
+                      fill="#ffffff"
+                    >
+                      {tag} 
+                  </text>
+                    <circle cx={centerX} cy={groupIndex % 2 === 0 ? -110 : 110} r={10} fill="#ffffff" />
+                  </g>
+                );
+              })}
+            </svg>
+          </div>
+        </div>
+        <div className='lg:hidden w-full h-full flex justify-center items-center'>
+        <Slider {...settings} className="w-full mt-4">
           {Object.keys(groupedSkills).map((tag, groupIndex) => {
-            const skills = groupedSkills[tag];
-            const xOffset = currentXOffset;
-            const yOffset = groupIndex % 2 === 0 ? 160 : -60; // 그룹 인덱스에 따라 Y축 오프셋 조정
-
-            // 다음 그룹의 시작 위치를 계산
-            currentXOffset += skills.length * itemSpacing + groupSpacing;
-
-            const centerX = (skills.length * itemSpacing) / 2 - 50;
+            const groupWidth = (groupedSkills[tag].length - 1) * 150; // 각 아이템의 간격 (150px)
+            const centerX = 500; // circle의 중심 위치
+            const groupStartX = centerX - groupWidth / 2; // 그룹 시작 X 위치 계산
 
             return (
-              <g key={tag} transform={`translate(${xOffset},${yOffset})`}>
-                {/* 각 스킬을 가로로 일렬로 배치 (itemIndex * itemSpacing 만큼 오른쪽으로 이동) */}
-                {skills.map((skill, itemIndex) => (
-                  <g key={skill.id} transform={`translate(${itemIndex * itemSpacing}, 0)`}>
-                    <SkillNode
-                      skill={skill}
-                      scale={0.5}
-                      isSelected={false}
-                      onSelect={undefined}
-                      onDrag={undefined}
+              <div key={tag} className="w-full p-4">
+                <div className="relative w-full scale-[2.2] xs:scale-[2.0]">
+                  <svg
+                    width="100%"
+                    height="80px"
+                    viewBox="-50 -100 1100 300"
+                    className="flex items-center"
+                  >
+                    <line
+                      x1={-100}
+                      y1={100}
+                      x2={1100}
+                      y2={100}
+                      stroke="#ffffff"
+                      strokeWidth="5"
                     />
-                  </g>
-                ))}
-                <text 
-                  x={centerX} 
-                  y={groupIndex % 2 === 0 ? -70 : 90} 
-                  textAnchor="middle" 
-                  fontSize="25" 
-                  fontWeight="bold" 
-                  fill="#ffffff"
-                >
-                  {tag} 
-               </text>
-                <circle cx={centerX} cy={groupIndex % 2 === 0 ? -110 : 110} r={10} fill="#ffffff" />
-              </g>
+                    <g transform={`translate(${groupStartX}, 0)`}>
+                      {groupedSkills[tag].map((skill, itemIndex) => (
+                        <g
+                          key={skill.id}
+                          transform={`translate(${itemIndex * 150}, 0)`} // itemSpacing 조정
+                        >
+                          <SkillNode
+                            skill={skill}
+                            scale={0.5}
+                            isSelected={false}
+                            onSelect={undefined}
+                            onDrag={undefined}
+                          />
+                        </g>
+                      ))}
+                    </g>
+                    <text 
+                      x={centerX} 
+                      y={150} 
+                      textAnchor="middle" 
+                      fontSize="25" 
+                      fontWeight="bold" 
+                      fill="#ffffff"
+                    >
+                      {tag} 
+                    </text>
+                    <circle cx={centerX} cy={100} r={10} fill="#ffffff" />
+                  </svg>
+                </div>
+              </div>
             );
           })}
-        </svg>
+        </Slider>
+        </div>
       </div>
     </div>
   );

--- a/src/main/frontend/src/app/category/pageComponents.tsx
+++ b/src/main/frontend/src/app/category/pageComponents.tsx
@@ -60,7 +60,7 @@ export default function CategoryPage() {
   const [selectedSkillPng, setSelectedSkillPng] = useState<string>("");
   const [skillDetailData, setSkillDetailData] = useState<SkillDetail | null>(null);
   const [isDetailVisible, setIsDetailVisible] = useState<boolean>(false);
-
+  const [triggerAction, setTriggerAction] = useState<null | 'increase' | 'decrease'>(null);
   useEffect(() => {
     // 백엔드에서 데이터 가져오기
     const fetchData = async () => {
@@ -131,10 +131,25 @@ export default function CategoryPage() {
       console.error("Error fetching mastery details:", error);
     }
   };
+
+  // 로드맵 크기 관련 트리거 
+  // 1) 로드맵 확장 트리거
+  const handleIncreaseSize = () => {
+    setTriggerAction('increase'); 
+  };
+  // 2) 로드맵 축소 트리거
+  const handleDecreaseSize = () => {
+    setTriggerAction('decrease'); 
+  };
+  // 3) 초기화 트리거
+  const resetAction = () => {
+    setTriggerAction(null);
+  };
+  
   return (
     <div className="w-full h-screen flex flex-col items-center">
-      <div className='w-dvw h-40 flex flex-row items-center justify-center border-b border-gray-d9'>
-        <div className='w-[1000px] h-full flex flex-row items-center justify-between'>
+      <div className='w-full h-40 flex flex-row items-center justify-center border-b border-gray-d9'>
+        <div className='max-w-[1400px] w-full h-full py-2 sm:py-0 px-4 2xl:w-[1400px] xl:px-20 lg:px-10 h-full grid grid-cols-3 sm:grid-cols-5 flex flex-row items-center justify-between'>
           {categories.map(c => (
             <div key={c} onClick={()=>selectCategory(c)}>
               <CategoryButton key={c} category={c} />
@@ -142,24 +157,46 @@ export default function CategoryPage() {
           ))}
         </div>
       </div>
-      <div className="w-[1400px] h-full flex flex-col items-center">
-        <div className='w-full px-24'>
+      <div className="max-w-[1400px] w-full h-full px-4 2xl:w-[1400px] xl:px-20 lg:px-10 flex flex-col items-center mb-10">
+        <div className='w-full'>
           <TimelineRoadmap category={category} skills={roadmapSkills}/>
         </div>
-        <div className='w-full flex flex-col px-24'>
+        <div className='w-full flex flex-col pb-10'>
           <div className="flex flex-col">
             <div className="font-bold">RoadMap</div>
-            <div className={`font-semibold text-category-${category} mb-5`}>{categoryName}</div>
+            <div className={`font-semibold text-category-${category} mb-2`}>{categoryName}</div>
           </div>
-          <Roadmap isEditMode={false} roadmapSkills={roadmapSkills} onSelectDetail={onSelectDetail}/>
+          <div className='w-40 sm:w-56 lg:w-60 flex justify-between mb-2 '>
+            <div
+              onClick={handleDecreaseSize}
+              className="bg-primary text-white text-xs sm:text-sm lg:text-base px-2 sm:px-4 py-2 rounded-xl cursor-pointer"
+            >
+              {'축소하기(-)'}
+            </div>
+            <div
+              onClick={handleIncreaseSize}
+              className="bg-primary text-white text-xs sm:text-sm lg:text-base px-2 sm:px-4 py-2 rounded-xl cursor-pointer"
+            >
+              {'확대하기(+)'}
+            </div>
+          </div>
+          <Roadmap 
+            style={'h-[40dvh] sm:h-[70dvh] md:h-dvh'}
+            isEditMode={false} 
+            roadmapSkills={roadmapSkills} 
+            onTriggerAction={triggerAction}
+            onSelectDetail={onSelectDetail}
+            onResetAction={resetAction}
+          />
         </div>
       </div>
       {isDetailVisible && (
-          <SkillDetailModal
-              skillDetail={skillDetailData as SkillDetail}
-              selectedSkillPng={selectedSkillPng}
-              onClose={() => setIsDetailVisible(false)}
-          />
+        <SkillDetailModal
+          style={'w-full border-none'}
+          skillDetail={skillDetailData as SkillDetail}
+          selectedSkillPng={selectedSkillPng}
+          onClose={() => setIsDetailVisible(false)}
+        />
       )}
     </div>
   );

--- a/src/main/frontend/src/app/customRoadmap/SkillDetailModal.tsx
+++ b/src/main/frontend/src/app/customRoadmap/SkillDetailModal.tsx
@@ -4,12 +4,14 @@ import { ExitIcon } from "@/components/icon";
 import QuizModal from "./QuizModal";
 
 type SkillDetailModalProps = {
+    style?: string;
     skillDetail: SkillDetail;
     selectedSkillPng: string;
     onClose: () => void;
 };
 
 const SkillDetailModal: React.FC<SkillDetailModalProps> = ({
+                                                                style,
                                                                skillDetail,
                                                                selectedSkillPng,
                                                                onClose,
@@ -67,7 +69,7 @@ const SkillDetailModal: React.FC<SkillDetailModalProps> = ({
 
     return (
         <div className="fixed inset-0 bg-black bg-opacity-60 flex justify-end items-center z-50">
-            <div className="bg-white p-5 w-1/3 h-full overflow-y-auto">
+            <div className={`bg-white p-5 ${style ? style : "w-1/3"} h-full overflow-y-auto scrollbar`}>
                 <div className="flex justify-between items-center mb-2">
                     <div className="flex items-center pl-5">
                         <img className="w-12 h-auto" src={selectedSkillPng} alt={skillDetail.name} />

--- a/src/main/frontend/src/app/mypage/UserProfile.tsx
+++ b/src/main/frontend/src/app/mypage/UserProfile.tsx
@@ -5,6 +5,7 @@ import {UpdateUserProfile, User, UserSkill} from "@/models/user";
 type UserProfileProps = {
   userInfo?: User
   badgeInfo?: UserSkill[]
+  isOwnUser: boolean
   onSave: (updateProfileBody: UpdateUserProfile) => void;
 };
 
@@ -20,6 +21,7 @@ const categoryLabels: Record<string, string> = {
 export default function UserProfile({
   userInfo,
   badgeInfo,
+  isOwnUser,
   onSave
 }:UserProfileProps) {
   const [isEditing, setIsEditing] = useState(false); 
@@ -185,7 +187,7 @@ export default function UserProfile({
             </div>
           </div>
         </div>
-        {userInfo === undefined && (
+        {userInfo !== undefined && isOwnUser && (
         <div 
           className='w-1/12 h-1/12 flex justify-center items-center border-2 border-primary rounded-xl p-2 cursor-pointer'
           onClick={isEditing ? saveProfile : changeProfileMode}

--- a/src/main/frontend/src/app/mypage/pageComponents.tsx
+++ b/src/main/frontend/src/app/mypage/pageComponents.tsx
@@ -10,9 +10,6 @@ import {CustomRoadmapDetail} from "@/models/roadmap";
 import {UpdateUserProfile, User, UserRecommendCompany, UserSkill} from '@/models/user';
 import { useUserContext } from '@/context/UserContext';
 
-// TODO: API 연결 -> 유저의 커스텀 로드맵 리스트
-// TODO: API 연결 -> customRoadmapList에서 선택된 로드맵의 id로 api호출
-// TODO: API 연결
 type MypagePageProps = {
   user_id?: number;
 };
@@ -23,6 +20,7 @@ export default function MypagePage({
   const { loggedInUserId, mypageUserId  } = useUserContext();
   console.log("user_id:", user_id);
   const [pageUserId, setPageUserId] = useState<number>();
+  const [isOwnUser, setIsOwnUser] = useState<boolean>(false);
   const [userInfo, setUserInfo] = useState<User>();
   const [badgeInfo, setBadgeInfo] = useState<UserSkill[]>([]);
   const [cardInfos, setCardInfos] = useState<AiCard[]>([]);
@@ -58,9 +56,11 @@ export default function MypagePage({
   useEffect(()=>{
     if(user_id) {
       setPageUserId(user_id);
+      setIsOwnUser(false);
     } 
     else if(loggedInUserId) { 
       setPageUserId(loggedInUserId);
+      setIsOwnUser(true);
     }
   },[user_id, loggedInUserId]);
 
@@ -176,7 +176,7 @@ export default function MypagePage({
     <div className="w-full h-full flex flex-col items-center mt-5">
       <div className='max-w-[1400px] w-full h-full px-4 2xl:w-[1400px] xl:px-20 lg:px-10'>
         <div className='w-full flex flex-col pb-5'>
-          <UserProfile userInfo={userInfo} badgeInfo={badgeInfo} onSave={onSaveProfile}/>
+          <UserProfile userInfo={userInfo} badgeInfo={badgeInfo} isOwnUser={isOwnUser} onSave={onSaveProfile}/>
         </div>
         <div className='w-full flex flex-col lg:flex-row justify-between mb-10 border-b border-gray-cc pb-10'>
           <div className='w-full lg:w-3/5 flex flex-col justify-start'>

--- a/src/main/frontend/src/components/Navbar.tsx
+++ b/src/main/frontend/src/components/Navbar.tsx
@@ -48,35 +48,35 @@ const NavigationBar = () =>{
                 <ul
                     className={`${
                         menuOpen ? "flex" : "hidden"
-                    } lg:flex flex-col lg:flex-row space-y-4 lg:space-y-0 lg:space-x-12 items-center absolute lg:static top-16 left-0 right-0 bg-white lg:bg-transparent z-50 shadow-lg lg:shadow-none p-5 lg:p-0`}
+                    } lg:flex flex-col lg:flex-row space-y-4 lg:space-y-0 lg:space-x-8 xl:space-x-12 items-center absolute lg:static top-16 left-0 right-0 bg-white lg:bg-transparent z-50 shadow-lg lg:shadow-none p-5 lg:p-0`}
                 >
                     <li onClick={toggleMenu}>
-                        <Link href="/category" className="hover:underline text-[0.7rem] font-gmarketsansBold xl:text-sm font-gmarketsansMedium">
+                        <Link href="/category" className="hover:underline text-[0.7rem] font-gmarketsansBold lg:text-sm font-gmarketsansMedium">
                         직무별로드맵
                         </Link>
                     </li>
                     <li onClick={toggleMenu}>
-                        <Link href="/lounge" className="hover:underline text-[0.7rem] font-gmarketsansBold xl:text-sm font-gmarketsansMedium">
+                        <Link href="/lounge" className="hover:underline text-[0.7rem] font-gmarketsansBold lg:text-sm font-gmarketsansMedium">
                         커리어라운지
                         </Link>
                     </li>
                     <li onClick={toggleMenu}>
-                        <Link href={isAuthenticated ? "/card" : "/signin"} className="hover:underline text-[0.7rem] font-gmarketsansBold xl:text-sm font-gmarketsansMedium">
+                        <Link href={isAuthenticated ? "/card" : "/signin"} className="hover:underline text-[0.7rem] font-gmarketsansBold lg:text-sm font-gmarketsansMedium">
                         AI경험카드
                         </Link>
                     </li>
                     <li onClick={toggleMenu}>
-                        <Link href={isAuthenticated ? "/aiChatbot" : "/signin"} className="hover:underline text-[0.7rem] font-gmarketsansBold xl:text-sm font-gmarketsansMedium">
+                        <Link href={isAuthenticated ? "/aiChatbot" : "/signin"} className="hover:underline text-[0.7rem] font-gmarketsansBold lg:text-sm font-gmarketsansMedium">
                         AI경험Chat
                         </Link>
                     </li>
                     <li onClick={toggleMenu}>
-                        <Link href={isAuthenticated ? "/customRoadmap" : "/signin"} className="hover:underline text-[0.7rem] font-gmarketsansBold xl:text-sm font-gmarketsansMedium">
+                        <Link href={isAuthenticated ? "/customRoadmap" : "/signin"} className="hover:underline text-[0.7rem] font-gmarketsansBold lg:text-sm font-gmarketsansMedium">
                         커스텀로드맵
                         </Link>
                     </li>
                     <li onClick={toggleMenu}>
-                        <Link href={isAuthenticated ? "/mypage" : "/signin"} className="hover:underline text-[0.7rem] font-gmarketsansBold xl:text-sm font-gmarketsansMedium">
+                        <Link href={isAuthenticated ? "/mypage" : "/signin"} className="hover:underline text-[0.7rem] font-gmarketsansBold lg:text-sm font-gmarketsansMedium">
                         마이페이지
                         </Link>
                     </li>


### PR DESCRIPTION
### Description
직무별 로드맵 페이지 모바일 반응형 UI 작업입니다.
타임라인 로드맵때문에 구상이 오래걸렷는데, 1024px 기준으로 더 작은 모바일화면에서는 **만능 캐러셀**을 넣었습니다.
Tag별로 스킬은 3개씩으로 제한하기로 했기때문에, DB 조정하면 더 예뻐질 예정입니다. 한번 보시고 별로면 말씀해주세용
### Changes

### Results
모바일뷰 직무별 로드맵 페이지
![image](https://github.com/user-attachments/assets/625e6ab5-0522-46a0-82c0-89f53d6d9141)
모바일뷰 스킬 상세창
![image](https://github.com/user-attachments/assets/e21e3c4a-5bbc-4551-b36b-93d93cedcf6b)
